### PR TITLE
fix: fix options "select-file" type err

### DIFF
--- a/options.go
+++ b/options.go
@@ -104,7 +104,7 @@ type Options struct {
 	RPCSaveUploadMetadata         string  `json:"rpc-save-upload-metadata,omitempty"`
 	SeedRatio                     float32 `json:"seed-ratio,omitempty,string"`
 	SeedTime                      uint    `json:"seed-time,omitempty,string"`
-	SelectFile                    bool    `json:"select-file,omitempty,string"`
+	SelectFile                    string  `json:"select-file,omitempty"`
 	Split                         uint    `json:"split,omitempty,string"`
 	SSHHostKeyMD                  string  `json:"ssh-host-key-md,omitempty"`
 	StreamPieceSelector           string  `json:"stream-piece-selector,omitempty"`


### PR DESCRIPTION
"SelectFile" should not be bool but string

> [--select-file=\<INDEX\>](https://aria2.github.io/manual/en/html/aria2c.html#cmdoption-select-file)
  Set file to download by specifying its index. You can find the file index using the [--show-files] 
  (https://aria2.github.io/manual/en/html/aria2c.html#cmdoption-S) option. Multiple indexes can be specified by using ,, for 
  example: 3,6. You can also use - to specify a range: 1-5. , and - can be used together: 1-5,8,9. When used with the -M option, 
  index may vary depending on the query (see --metalink-* options).