### PR TITLE
fix announceList incorrect type

### DIFF
--- a/status.go
+++ b/status.go
@@ -118,7 +118,7 @@ type BitTorrentStatus struct {
 	// List of lists of announce URIs.
 	// If the torrent contains announce and no announce-list,
 	// announce is converted to the announce-list format
-	AnnounceList []URI                `json:"announceList"`
+	AnnounceList [][]string           `json:"announceList"`        // List of lists of announce URIs.
 	Comment      string               `json:"comment"`             // The comment of the torrent
 	CreationDate UNIXTime             `json:"creationDate,string"` // The creation time of the torrent
 	Mode         TorrentMode          `json:"mode"`                // File mode of the torrent

--- a/status_test.go
+++ b/status_test.go
@@ -2,13 +2,27 @@ package arigo
 
 import (
 	"encoding/json"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestStatusFormat(t *testing.T) {
 	data := []byte(`{
 		"bitfield": "0000000000",
+		"bittorrent": {
+			"announceList": [
+				[
+					"http://tracker.example.com:80/announce"
+				]
+			],
+			"comment": "Torrent downloaded from https://example.com",
+			"creationDate": 1520238244,
+			"info": {
+				"name": "example.mkv"
+			},
+			"mode": "multi"
+		},
 		"completedLength": "901120",
 		"connections": "1",
 		"dir": "/downloads",


### PR DESCRIPTION
Status.BitTorrent.AnnounceList should be a [][]string type.  
Here is one example of a bittorrent respond I found on internet.
```
{
    "id": "root",
    "jsonrpc": "2.0",
    "result": [
        {
            "bitfield": "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
            "bittorrent": {
                "announceList": [
                    [
                        "http://tracker.trackerfix.com:80/announce"
                    ],
                    [
                        "udp://9.rarbg.me:2710/announce"
                    ],
                    [
                        "udp://9.rarbg.to:2710/announce"
                    ]
                ],
                "comment": "Torrent downloaded from https://rarbg.to",
                "creationDate": 1520238244,
                "info": {
                    "name": "Paddington.2.2017.1080p.WEB-DL.DD5.1.H264-FGT"
                },
                "mode": "multi"
            },
            "completedLength": "0",
            "connections": "0",
            "dir": "/data/diskall/admin/files/Downloads/",
            "downloadSpeed": "0",
            "files": [
                {
                    "completedLength": "0",
                    "index": "1",
                    "length": "3826706646",
                    "path": "/data/diskall/admin/files/Downloads//Paddington.2.2017.1080p.WEB-DL.DD5.1.H264-FGT/Paddington.2.2017.1080p.WEB-DL.DD5.1.H264-FGT.mkv",
                    "selected": "true",
                    "uris": []
                },
                {
                    "completedLength": "0",
                    "index": "2",
                    "length": "31",
                    "path": "/data/diskall/admin/files/Downloads//Paddington.2.2017.1080p.WEB-DL.DD5.1.H264-FGT/RARBG.txt",
                    "selected": "true",
                    "uris": []
                }
            ],
            "gid": "aa5c55401362140b",
            "infoHash": "9f1eac15eb1eaf83bb7b8cf654c95c2d31c6451d",
            "numPieces": "3650",
            "numSeeders": "0",
            "pieceLength": "1048576",
            "seeder": "false",
            "status": "active",
            "totalLength": "3826706677",
            "uploadLength": "0",
            "uploadSpeed": "0"
        }
    ]
}
```